### PR TITLE
Extended endpoints and documentation

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -18,6 +18,8 @@ pm4py = "*"
 flask-executor = "*"
 pandas = "*"
 flask-cors = "*"
+python-datauri = "*"
+flasgger = "*"
 
 [requires]
 python_version = "3.8"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e3c723819af96f54d41d8479cfa6fb09c9fe53ef246eabaaa8381fe429b652ff"
+            "sha256": "3bb2b5e6e29d6fe915285bcab7855808667b122931fe9105389f410a1e47396b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==19.3.0"
+        },
         "backcall": {
             "hashes": [
                 "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e",
@@ -65,6 +73,14 @@
                 "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"
             ],
             "version": "==2.1.0"
+        },
+        "flasgger": {
+            "hashes": [
+                "sha256:37137b3292738580c42e03662bfb8731656a11d636e76f76d30e572c1fa5bd0d",
+                "sha256:7c187f7a7caeb42645f7de652335b794375925467407e40322620fb9d401b38c"
+            ],
+            "index": "pypi",
+            "version": "==0.9.4"
         },
         "flask": {
             "hashes": [
@@ -166,6 +182,13 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.15.1"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+            ],
+            "version": "==3.2.0"
         },
         "kiwisolver": {
             "hashes": [
@@ -282,6 +305,13 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.2.2"
+        },
+        "mistune": {
+            "hashes": [
+                "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e",
+                "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"
+            ],
+            "version": "==0.8.4"
         },
         "networkx": {
             "hashes": [
@@ -425,15 +455,29 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:28669905fe725965daa16184933676547c5bb40a5153055a8dee2a4bd7933ad3"
+            ],
+            "version": "==0.16.0"
+        },
+        "python-datauri": {
+            "hashes": [
+                "sha256:5d6062ff85bc785a2230c40151d5aded80f1ce8652d5a31e3a64c78aa6e52a20",
+                "sha256:68e8699cf2754a66f185f486c8d4c73e7ee5304aa53253bad0434fdbbde3f0b7"
+            ],
+            "index": "pypi",
+            "version": "==0.2.8"
         },
         "python-dateutil": {
             "hashes": [
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "pytz": {
@@ -449,6 +493,22 @@
                 "sha256:d94ae87d1670af7b3c526e75545b5d59aa5b181c7a83ae903f08f4b5f1929e58"
             ],
             "version": "==0.1.8.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
+                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
+                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+            ],
+            "version": "==5.3.1"
         },
         "requests": {
             "hashes": [
@@ -507,7 +567,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "sortedcontainers": {
@@ -536,7 +596,7 @@
                 "sha256:07c06493f1403c1380b630ae3dcbe5ae62abcf369a93bbc052502279f189ab8c",
                 "sha256:cd140979c2bebd2311dfb14781d8f19bd5a9debb92dcab9f6ef899c987fcf71f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==4.46.1"
         },
         "traitlets": {
@@ -556,10 +616,10 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
-                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
-            "version": "==0.2.4"
+            "version": "==0.2.5"
         },
         "werkzeug": {
             "hashes": [
@@ -745,11 +805,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44",
-                "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.8.2"
+            "version": "==1.9.0"
         },
         "pylint": {
             "hashes": [
@@ -764,7 +824,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -820,7 +880,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "smmap": {
@@ -856,10 +916,10 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
-                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
-            "version": "==0.2.4"
+            "version": "==0.2.5"
         },
         "wrapt": {
             "hashes": [

--- a/backend/process_miner/__init__.py
+++ b/backend/process_miner/__init__.py
@@ -18,7 +18,7 @@ import process_miner.logs_process_miner as pm
 import process_miner.mining.graph_factory as gf
 import process_miner.mining.metadata_factory as mf
 from process_miner.access.blueprints import logs, request_result, graphs, \
-                                            metadata
+    metadata
 from process_miner.access.work.request_processing import RequestManager
 
 CONFIG_FILENAME = 'process_miner_config.yaml'
@@ -88,7 +88,8 @@ def create_app():
     used_blueprints = [
         request_result.create_blueprint(request_manager),
         logs.create_blueprint(request_manager, cache, retriever),
-        graphs.create_blueprint(request_manager, cache, graph_factory),
+        graphs.create_blueprint(request_manager, cache, graph_factory,
+                                metadata_factory),
         metadata.create_blueprint(request_manager, cache, metadata_factory)
     ]
     # register created blueprints on the flask app

--- a/backend/process_miner/__init__.py
+++ b/backend/process_miner/__init__.py
@@ -74,8 +74,9 @@ def create_app():
     (retriever, graph_factory, metadata_factory, _) = setup_components()
     log.info('setting up flask app')
     process_miner_app = Flask(__name__)
-    swagger = Swagger(process_miner_app)
-    log.info('swagger %s set up', swagger)
+    Swagger(process_miner_app)
+    # TODO create that url dynamically
+    log.info('SwaggerUI reachable at http://localhost:5000/apidocs/index.html')
     # enable cross origin resource sharing
     # TODO evaluate if this is required in the final application
     CORS(process_miner_app)

--- a/backend/process_miner/__init__.py
+++ b/backend/process_miner/__init__.py
@@ -5,6 +5,7 @@ service of the process miner.
 import logging
 from pathlib import Path
 
+from flasgger import Swagger
 from flask import Flask
 from flask_caching import Cache
 from flask_cors import CORS
@@ -73,6 +74,8 @@ def create_app():
     (retriever, graph_factory, metadata_factory, _) = setup_components()
     log.info('setting up flask app')
     process_miner_app = Flask(__name__)
+    swagger = Swagger(process_miner_app)
+    log.info('swagger %s set up', swagger)
     # enable cross origin resource sharing
     # TODO evaluate if this is required in the final application
     CORS(process_miner_app)

--- a/backend/process_miner/access/blueprints/graphs.py
+++ b/backend/process_miner/access/blueprints/graphs.py
@@ -24,15 +24,21 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
     """
     blueprint = Blueprint('graphs', __name__, url_prefix='/graphs')
 
-    @cache.memoize()
     def _get_checked_approach():
-        valid_approach_types = metadata_factory.get_approach_types()
+        valid_approach_types = _wrapper_get_approach_types()
         return _get_checked_str_arg('approach', valid_approach_types, '')
 
     @cache.memoize()
+    def _wrapper_get_approach_types():
+        return metadata_factory.get_approach_types()
+
     def _get_checked_consent():
-        valid_consent_types = metadata_factory.get_consent_types()
+        valid_consent_types = _wrapper_get_consent_types()
         return _get_checked_str_arg('consent', valid_consent_types, '')
+
+    @cache.memoize()
+    def _wrapper_get_consent_types():
+        return metadata_factory.get_consent_types()
 
     def _get_checked_str_arg(arg: str, valid_values: List[str],
                              default_value: str):

--- a/backend/process_miner/access/blueprints/graphs.py
+++ b/backend/process_miner/access/blueprints/graphs.py
@@ -1,6 +1,8 @@
 """
 Blueprint module responsible for retrieving different graph types
 """
+import logging
+from typing import List
 
 import datauri
 from flask import Blueprint, request
@@ -9,14 +11,37 @@ from flask_caching import Cache
 from process_miner.access.blueprints.request_result import get_state_response
 from process_miner.access.work.request_processing import RequestManager
 from process_miner.mining.graph_factory import GraphFactory
+from process_miner.mining.metadata_factory import MetadataFactory
+
+log = logging.getLogger(__name__)
 
 
 def create_blueprint(request_manager: RequestManager, cache: Cache,
-                     graph_factory: GraphFactory):
+                     graph_factory: GraphFactory,
+                     metadata_factory: MetadataFactory):
     """
     Creates an instance of the blueprint.
     """
     blueprint = Blueprint('graphs', __name__, url_prefix='/graphs')
+
+    @cache.memoize()
+    def _get_checked_approach():
+        valid_approach_types = metadata_factory.get_approach_types()
+        return _get_checked_str_arg('approach', valid_approach_types, '')
+
+    @cache.memoize()
+    def _get_checked_consent():
+        valid_consent_types = metadata_factory.get_consent_types()
+        return _get_checked_str_arg('consent', valid_consent_types, '')
+
+    def _get_checked_str_arg(arg: str, valid_values: List[str],
+                             default_value: str):
+        value = request.args.get(arg, default_value, str).lower()
+        if value == default_value or value in valid_values:
+            return value
+        log.warning('unknown value "%s" for argument "%s"; using default "%s"',
+                    value, arg, default_value)
+        return default_value
 
     @cache.memoize()
     def _create_dfg(approach):
@@ -24,9 +49,10 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
         return _package_response(graph)
 
     @cache.memoize()
-    def _create_heuristic_net(approach, threshold, output_format):
-        graph = graph_factory.get_heuristic_net(approach, threshold,
-                                                output_format)
+    def _create_heuristic_net(approach, consent_type, threshold,
+                              output_format):
+        graph = graph_factory.get_heuristic_net(approach, consent_type,
+                                                threshold, output_format)
         return _package_response(graph)
 
     def _package_response(graph):
@@ -43,7 +69,7 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
         """
         Triggers the creation of a Directly Follows Graph.
         """
-        approach = request.args.get('approach', '', str).lower()
+        approach = _get_checked_approach()
         ticket = request_manager.submit_ticketed(_create_dfg, approach)
         return get_state_response(ticket)
 
@@ -59,6 +85,13 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
             default: ''
             example: 'embedded'
             description: the approach the data used for creating the graph
+                         should be limited to
+          - name: consent_type
+            in: query
+            type: string
+            default: ''
+            example: 'get_transactions'
+            description: the consent type the data used for creating the graph
                          should be limited to
           - name: threshold
             in: query
@@ -77,11 +110,14 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
             schema:
               $ref: '#/definitions/RequestResponse'
         """
-        approach = request.args.get('approach', '', str).lower()
+        approach = _get_checked_approach()
+        consent_type = _get_checked_consent()
         threshold = request.args.get('threshold', 0.0, float)
+        # TODO check output_format parameter
         output_format = request.args.get('format', 'svg', str).lower()
         ticket = request_manager.submit_ticketed(_create_heuristic_net,
-                                                 approach, threshold,
+                                                 approach, consent_type,
+                                                 threshold,
                                                  output_format)
         return get_state_response(ticket)
 

--- a/backend/process_miner/access/blueprints/graphs.py
+++ b/backend/process_miner/access/blueprints/graphs.py
@@ -51,6 +51,31 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
     def get_hn():
         """
         Triggers the creation of a Heuristic net.
+        ---
+        parameters:
+          - name: approach
+            in: query
+            type: string
+            default: ''
+            example: 'embedded'
+            description: the approach the data used for creating the graph
+                         should be limited to
+          - name: threshold
+            in: query
+            type: float
+            minimum: 0
+            maximum: 1
+            default: '0'
+          - name: output_format
+            in: query
+            type: string
+            default: 'svg'
+        responses:
+          200:
+            description: The result will contain a base64 encoded DataURI
+                         representing the generated graph.
+            schema:
+              $ref: '#/definitions/RequestResponse'
         """
         approach = request.args.get('approach', '', str).lower()
         threshold = request.args.get('threshold', 0.0, float)

--- a/backend/process_miner/access/blueprints/logs.py
+++ b/backend/process_miner/access/blueprints/logs.py
@@ -28,6 +28,19 @@ def create_blueprint(executor, cache, log_retriever):
     def refresh():
         """
         Triggers the retrieval of logs from Graylog.
+        ---
+        parameters:
+          - name: force
+            in: query
+            type: boolean
+            default: 'False'
+            description: force retrieval of logs that were already downloaded
+        responses:
+          200:
+            description: The result will not contain any value after retrieval.
+            application/json:
+              schema:
+                $ref: '#/definitions/RequestResponse'
         """
         ticket = executor.submit_ticketed(_refresh_logs)
         return get_state_response(ticket)

--- a/backend/process_miner/access/blueprints/metadata.py
+++ b/backend/process_miner/access/blueprints/metadata.py
@@ -33,7 +33,7 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
         response:
           200:
             description: The retrieved result will be a JSON object
-                         representing the number of different consent types pre
+                         representing the number of different consent types per
                          approach.
             application/json:
               schema:

--- a/backend/process_miner/access/blueprints/metadata.py
+++ b/backend/process_miner/access/blueprints/metadata.py
@@ -29,6 +29,15 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
     def get_consent_count():
         """
         Triggers calculation of number of consent types per approach.
+        ---
+        response:
+          200:
+            description: The retrieved result will be a JSON object
+                         representing the number of different consent types pre
+                         approach.
+            application/json:
+              schema:
+                $ref: '#/definitions/RequestResponse'
         """
         ticket = request_manager.submit_ticketed(_count_consent_type_counts)
         return get_state_response(ticket)
@@ -38,6 +47,15 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
         """
         Computes which approach types are present in the available data and how
         many sessions each of them was used in.
+        ---
+        response:
+          200:
+            description: The retrieved result will be a JSON object
+                         representing the number of sessions each approach was
+                         used in.
+            application/json:
+              schema:
+                $ref: '#/definitions/RequestResponse'
         """
         ticket = request_manager.submit_ticketed(_count_approach_type_counts)
         return get_state_response(ticket)

--- a/backend/process_miner/access/blueprints/request_result.py
+++ b/backend/process_miner/access/blueprints/request_result.py
@@ -35,8 +35,36 @@ def create_blueprint(request_manager):
     def get_state(request_id):
         """
         Retrieves the state of the specified request.
-        :param request_id: id of the request
-        :return: JSON object representing the requests state
+        ---
+        parameters:
+          - name: request_id
+            description: id of the request
+            in: path
+            type: string
+            required: true
+        definitions:
+          RequestResponse:
+            description: Object containing the URL of a requests state
+            type: object
+            properties:
+              stateUrl:
+                description: URL the requests state can be retrieved from
+                type: string
+          StateResponse:
+            description: Object describing request state and result url
+            type: object
+            properties:
+              done:
+                description: whether the processing of the request is done
+                type: boolean
+              resultUrl:
+                description: URL the requests result can be retrieved from
+                type: string
+        responses:
+          200:
+            application/json:
+              schema:
+                $ref: '#/definitions/StateResponse'
         """
         # TODO 404 on invalid request_id or no futures
         return jsonify({
@@ -51,8 +79,19 @@ def create_blueprint(request_manager):
     def get_result(request_id):
         """
         Retrieves the result of the specified request.
-        :param request_id: request_id: id of the request
-        :return: JSON object representing the requests state
+        ---
+        parameters:
+          - name: request_id
+            description: id of the request
+            in: path
+            type: string
+            required: true
+        responses:
+          200:
+            application/json:
+              schema:
+                description: object defined by the type of request
+                type: object
         """
         if not request_manager.request_processed(request_id):
             log.info('request "%s" not done or result already retrieved',

--- a/backend/process_miner/mining/graph_factory.py
+++ b/backend/process_miner/mining/graph_factory.py
@@ -46,11 +46,13 @@ def create_directly_follows_graph(event_log: EventLog):
     return visualization
 
 
-def create_heuristic_net(event_log: EventLog, threshold: float = 0.00):
+def create_heuristic_net(event_log: EventLog, threshold: float = 0.00,
+                         output_format: str = 'svg'):
     """
     Creates a Heuristic Net from the supplied EventLog.
     :param event_log: the EventLog
     :param threshold: the threshold to use during creation
+    :param output_format: desired output format
     :return: object representing the created graph
     """
     log.info('creating heuristic net with threshold %s', threshold)
@@ -59,7 +61,7 @@ def create_heuristic_net(event_log: EventLog, threshold: float = 0.00):
     })
 
     return hn_vis.apply(heu_net=heu_net, parameters={
-        hn_vis.Variants.PYDOTPLUS.value.Parameters.FORMAT: 'svg'
+        hn_vis.Variants.PYDOTPLUS.value.Parameters.FORMAT: output_format
     })
 
 
@@ -79,15 +81,17 @@ class GraphFactory:
         event_log = self._get_prepared_event_log(approach)
         return create_directly_follows_graph(event_log)
 
-    def get_heuristic_net(self, approach: str = None, threshold: float = 0.0):
+    def get_heuristic_net(self, approach: str = None, threshold: float = 0.0,
+                          output_format: str = 'svg'):
         """
         Creates a Heuristic Net from the available data.
         :param approach: approach that should be used (all if none specified)
         :param threshold: the threshold to use during creation
+        :param output_format: desired output format
         :return: object representing the created graph
         """
         event_log = self._get_prepared_event_log(approach)
-        return create_heuristic_net(event_log, threshold)
+        return create_heuristic_net(event_log, threshold, output_format)
 
     def _get_prepared_event_log(self, approach):
         frame = data_util.get_merged_csv_files(self._source_directory)

--- a/backend/process_miner/mining/graph_factory.py
+++ b/backend/process_miner/mining/graph_factory.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 COLUMN_MAPPINGS = {
     'timestamp': 'time:timestamp',
     'correlationId': 'case:concept:name',
-    'message': 'concept:name',
+    'label': 'concept:name',
     'approach': 'case:approach'
 }
 

--- a/backend/process_miner/mining/metadata_factory.py
+++ b/backend/process_miner/mining/metadata_factory.py
@@ -31,6 +31,16 @@ class MetadataFactory:
                                      aggfunc='size').to_dict()
         return _convert_to_multi_level_dict(raw_dict)
 
+    def get_consent_types(self):
+        """
+        Extracts all available consent types.
+        :return: list of all available consent types
+        """
+        types = set()
+        for value in self.get_consent_types_per_approach().values():
+            types.update(value.keys())
+        return list(types)
+
     def get_approach_type_count(self) -> Dict[str, int]:
         """
         Extracts all approach types and how many sessions they each were used
@@ -41,3 +51,10 @@ class MetadataFactory:
         relevant_rows = frame.loc[:, ['approach', 'correlationId']]
         unique_combinations = relevant_rows.drop_duplicates()
         return unique_combinations.groupby(['approach']).size().to_dict()
+
+    def get_approach_types(self):
+        """
+        Extracts all available approach types.
+        :return: list of all available approach types
+        """
+        return list(self.get_approach_type_count().keys())

--- a/backend/process_miner/mining/util/data.py
+++ b/backend/process_miner/mining/util/data.py
@@ -3,7 +3,7 @@ Utility module for working with log data in various formats
 """
 import logging
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 import pandas
 from pandas import DataFrame
@@ -23,13 +23,33 @@ def get_merged_csv_files(source: Path, sort_column: str = None) -> DataFrame:
     :param sort_column: column the resulting DataFrame should be sorted by
     :return: the resulting DataFrame
     """
+    csv_files = read_csv_files(source)
+    log.info('combining %s files from path %s', len(csv_files), source)
+    return merge_and_sort_dataframes(csv_files, sort_column)
+
+
+def read_csv_files(source: Path) -> List[DataFrame]:
+    """
+    Reads all CSV files from the specified path to DataFrames.
+    :param source: the source directory
+    :return: a list containing the DataFrames
+    """
     if not source.is_dir():
         log.error('%s is not a directory', source)
         raise Exception()
-
     files = source.glob(f"*.{FILE_EXTENSION}")
-    csv_files = [pandas.read_csv(file) for file in files]
-    log.info('combining %s files from path %s', len(csv_files), source)
+    return [pandas.read_csv(file) for file in files]
+
+
+def merge_and_sort_dataframes(csv_files: List[DataFrame],
+                              sort_column: str = None) -> DataFrame:
+    """
+    Merges the supplied DataFrames into a single DataFrame and optionally sorts
+    them by the supplied column.
+    :param csv_files: the initial DataFrames
+    :param sort_column: the column to sort by
+    :return: the resulting DataFrame
+    """
     frame = pandas.concat(csv_files)
     if not sort_column:
         return frame

--- a/backend/process_miner/mining/util/data.py
+++ b/backend/process_miner/mining/util/data.py
@@ -87,3 +87,15 @@ def filter_by_field(frame: DataFrame, field: str, value: str) -> DataFrame:
     """
     log.info('filtering log entries by value "%s" on field "%s"', value, field)
     return frame.loc[frame[field] == value]
+
+
+def dataframe_has_value_in_column(frame: DataFrame, column: str, value: str) \
+        -> DataFrame:
+    """
+    Determines if a column of a DataFrame contains a value.
+    :param frame: the DataFrame
+    :param column: the column
+    :param value: the value that should occur in that column
+    :return: whether the value was found in the column
+    """
+    return value in frame[column].values


### PR DESCRIPTION
- backend now allows specifying the desired graph output format
- endpoint documentation via Swagger (could be improved; url will be printed at application start)
- graphs may now be created based on a desired consent type