### PR TITLE
Error meta data and filter

### DIFF
--- a/backend/process_miner/access/blueprints/graphs.py
+++ b/backend/process_miner/access/blueprints/graphs.py
@@ -12,8 +12,6 @@ from process_miner.access.blueprints.request_result import get_state_response
 from process_miner.access.work.request_processing import RequestManager
 from process_miner.mining import graphs, metadata
 from process_miner.mining.dataset_factory import DatasetFactory
-from process_miner.mining.metadata import get_sessions_per_consent_type, \
-    get_sessions_per_bank
 
 log = logging.getLogger(__name__)
 
@@ -73,11 +71,13 @@ def create_blueprint(request_manager: RequestManager, cache: Cache,
         return _package_response(graph, session_count, additional_metadata)
 
     def _extract_metadata(frame):
-        consent_counts = get_sessions_per_consent_type(frame)
-        bank_counts = get_sessions_per_bank(frame)
+        consent_counts = metadata.get_sessions_per_consent_type(frame)
+        bank_counts = metadata.get_sessions_per_bank(frame)
+        error_counts = metadata.get_sessions_per_error_type(frame)
         return {
             'consents': consent_counts,
-            'banks': bank_counts
+            'banks': bank_counts,
+            'errors': error_counts
         }
 
     def _package_response(graph, session_count, additional_metadata):

--- a/backend/process_miner/mining/dataset_factory.py
+++ b/backend/process_miner/mining/dataset_factory.py
@@ -19,8 +19,8 @@ class DatasetFactory:
         return f'{self.__class__.__name__} [' \
                f'_source_directory <{self._source_directory}>]'
 
-    def get_prepared_data_frame(self, approach=None, consent_type=None) \
-            -> DataFrame:
+    def get_prepared_data_frame(self, approach=None, consent_type=None,
+                                error_type=None) -> DataFrame:
         """
         Creates a DataFrame for graph creation or metadata extraction.
         :param approach: approach that should be used (all if none specified)
@@ -37,4 +37,9 @@ class DatasetFactory:
         # filter by approach
         if approach:
             frame = data_util.filter_by_field(frame, 'approach', approach)
+
+        # filter by consent
+        if error_type:
+            frame = data_util.filter_related_entries(frame, 'correlationId',
+                                                     'errortype', [error_type])
         return frame

--- a/backend/process_miner/mining/metadata.py
+++ b/backend/process_miner/mining/metadata.py
@@ -12,9 +12,19 @@ log = logging.getLogger(__name__)
 DEFAULT_MISSING_VALUE = 'not available'
 
 
+def get_sessions_per_error_type(frame: DataFrame):
+    """
+    Counts number of sessions each error type occurs in in the supplied
+    DataFrame.
+    :param frame:
+    :return:
+    """
+    return _count_values_per_session(frame, 'errortype')
+
+
 def get_sessions_per_consent_type(frame: DataFrame):
     """
-    Counts number of session each consent type occurs in in the supplied
+    Counts number of sessions each consent type occurs in in the supplied
     DataFrame.
     :param frame: the DataFrame
     :return: dict containing number of occurrences
@@ -24,7 +34,7 @@ def get_sessions_per_consent_type(frame: DataFrame):
 
 def get_sessions_per_bank(frame: DataFrame):
     """
-    Counts number of session each bank occurs in in the supplied DataFrame.
+    Counts number of sessions each bank occurs in in the supplied DataFrame.
     :param frame: the DataFrame
     :return: dict containing number of occurrences
     """
@@ -43,7 +53,6 @@ def _count_values_per_session(frame, column):
     return counts
 
 
-# TODO: look for possible code deduplication (see count_consents)
 def get_consent_type_count_per_approach(frame: DataFrame):
     """
     Extracts the count of different approaches per consent type.


### PR DESCRIPTION
The graph endpoint now supports error types:
- added the number of sessions each error type occurred in to the graph response metadata
- the graph endpoint allows filtering by error type using the `error_type` argument