### PR TITLE
Scroll layout for processes page

### DIFF
--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,34 +1,45 @@
-.adorsys-blue{
-    background-color:#0984bf;
+/* app layout */
+html, body, .container-app {
+  height: 100%;
+  margin: 0;
 }
 
+.container-app {
+  display: flex;
+  flex-flow: column;
+}
+
+.container-header {
+  background-color: #0984bf;
+}
+
+.container-generated-content {
+  flex: 2;
+  overflow: auto;
+}
+
+/* toolbar layout */
 .toolbar-title {
-    font-family: 'Comfortaa', cursive;
-    color: #FFFFFF;
+  font-family: 'Comfortaa', cursive;
+  color: #FFFFFF;
 }
 
 .mat-button{
-    font-family: 'Montserrat', sans-serif;
-    color: rgba(255, 255, 255, 0.5);
+  font-family: 'Montserrat', sans-serif;
+  color: rgba(255, 255, 255, 0.5);
 }
 
 .mat-toolbar{
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  background-color:#0984bf;
 }
 
-.filler {
-    flex: 1 1 auto;
- }
-
-/* -------------------  LOGO ---------------------------  */
+img {
+  max-width: 100%;
+  max-height: 100%;
+}
 
 .container-logo {
-    width: 70px;
-    height: 60px;
-}
-
-.container-logo img {
-    padding: 10px 0;
-    width: 90%;
-    height: auto;
+  height: 100%;
+  width: auto;
 }

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,12 +1,18 @@
-<mat-toolbar class='adorsys-blue'>
-  <div class="container-logo">
-      <img src="assets/img/logo.png">
+<div class="container-main">
+  <div class="container-header">
+    <mat-toolbar>
+      <div class="container-logo">
+        <img class="image-logo" src="assets/img/logo.png">
+      </div>
+      <h1 class="toolbar-title">
+        &nbsp;PSD2Miner
+      </h1>
+      <div class="toolbar-items">
+        <button mat-button routerLink="/processes">Processes</button>
+      </div>
+    </mat-toolbar>
   </div>
-  <h1 class="toolbar-title">
-      PSD2Miner
-  </h1>
-  <div class="toolbar-items">
-      <button mat-button routerLink="/processes">Processes</button>
+  <div class="container-content">
+    <router-outlet></router-outlet>
   </div>
-</mat-toolbar>
-<router-outlet></router-outlet>
+</div>

--- a/frontend/src/app/graph-display/graph-display.component.html
+++ b/frontend/src/app/graph-display/graph-display.component.html
@@ -1,2 +1,1 @@
-
 <div id="graph"></div>

--- a/frontend/src/app/graph-display/graph-display.component.ts
+++ b/frontend/src/app/graph-display/graph-display.component.ts
@@ -9,15 +9,16 @@ import { graphviz } from 'd3-graphviz';
 export class GraphDisplayComponent implements OnChanges {
 
   @Input() dotString: string;
+  @Input() width: string;
+  @Input() height: string;
 
   constructor() { }
 
   ngOnChanges(): void {
     graphviz('#graph')
-      .width(1000)
-      .height(1000)
+      .width(parseInt(this.width, 10))
+      .height(parseInt(this.height, 10))
       .fit(true)
-      .scale(0.5)
       .renderDot(this.dotString);
   }
 }

--- a/frontend/src/app/processes/processes.component.css
+++ b/frontend/src/app/processes/processes.component.css
@@ -1,109 +1,129 @@
+.container-content {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+  height: 100%;
+  margin: 10px 10px 10px 10px;
+}
+
+.container-content-rows {
+  display: flex;
+  min-height: min-content;
+  height: 100%;
+}
+
+.instructions-text {
+  font-family: "Montserrat", sans-serif;
+  color: #ffffff;
+  background: #0984bf;
+  text-align: center;
+}
+
 .container-img {
-    width: 100%;
-    height: 100%;
-    border: 1px solid #C4C4C4;
-    box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.25);
-    border-radius: 8px;
-    margin: 0px 0px 0px 0px;
+  width: 100%;
+  height: 100%;
+  border: 1px solid #c4c4c4;
+  box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 8px;
+  margin: 0px 0px 0px 0px;
 }
-.container{
-    border: 1px solid #C4C4C4;
-    width: 100%;
-    height: 100%;
+
+.container-controls {
+  /* border: 1px solid #C4C4C4; */
+  width: 100%;
+  height: 100%;
+  font-family: "Montserrat", sans-serif;
+  color: #054f72;
+  align-items: center;
 }
-.overlay{
-    height:100vh;
-    width:100%;
-    background-color:rgba(0, 0, 0, 0.286);
-    z-index:    10;
-    top:        0; 
-    left:       0; 
-    position:   fixed;
-  }
+.overlay {
+  height: 100vh;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.286);
+  z-index: 10;
+  top: 0;
+  left: 0;
+  position: fixed;
+}
 .centerSpinner {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    -moz-transform: translateX(-50%) translateY(-50%);
-    -webkit-transform: translateX(-50%) translateY(-50%);
-    transform: translateX(-50%) translateY(-50%);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -moz-transform: translateX(-50%) translateY(-50%);
+  -webkit-transform: translateX(-50%) translateY(-50%);
+  transform: translateX(-50%) translateY(-50%);
 }
-:host ::ng-deep .custom-spinner circle{   
-    stroke: #0984BF;
+:host ::ng-deep .custom-spinner circle {
+  stroke: #0984bf;
 }
-.grid{
+.grid {
   margin: 20px 20px 0px 20px;
   height: 100%;
 }
 
+.load-graph-button {
+  font-family: "Montserrat", sans-serif;
+  color: #ffffff;
+  background: #054f72;
+}
+
+.reset-settings-button {
+  font-family: "Montserrat", sans-serif;
+  color: #ffffff;
+  background: #0984bf;
+}
+
+.container-filters {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  height: calc(100vh - 100px);
+}
+
 .zoom {
-    padding: 10px 0;
-    width: 100%;
-    height: 100%;
+  padding: 10px 0;
+  width: 100%;
+  height: 100%;
 }
-.instructions-text {
-    font-family: 'Montserrat', sans-serif;
-    color: #FFFFFF;;
-    background: #0984BF;
-    text-align: center;
+
+.controls-main-selectors {
+  padding: 27px 0px;
 }
-.container-controls{
-    width: 100%;
-    height: 100%;
-    font-family: 'Montserrat', sans-serif;
-    color: #054F72;
-    align-items: center;
-}
-.controls-main-selectors{
-    padding: 27px 0px;
-}
-.controls-main-selectors-labels{
-    padding: 18px 0px;
+.controls-main-selectors-labels {
+  padding: 18px 0px;
 }
 ::ng-deep .mat-accent .mat-slider-thumb {
-    background-color: #054F72;
+  background-color: #054f72;
 }
 ::ng-deep .mat-accent .mat-slider-track-fill {
-    background-color: #054F72;
+  background-color: #054f72;
 }
 ::ng-deep .mat-accent .mat-slider-thumb-label {
-    background-color: #054F72;
-}
-
-.load-graph-button{
-    font-family: 'Montserrat', sans-serif;
-    color: #FFFFFF;;
-    background: #054f72;
+  background-color: #054f72;
 }
 ::ng-deep.mat-form-field-ripple {
-    /*change color of underline when focused*/
-    background-color: #054F72 !important;;
-    color: white!important;;
+  /*change color of underline when focused*/
+  background-color: #054f72 !important;
+  color: white !important;
 }
 
-.reset-settings-button{
-    font-family: 'Montserrat', sans-serif;
-    color: #FFFFFF;;
-    background: #0984BF;
-}
-
-.example-radio-group {
+.error-radio-group {
   display: flex;
   flex-direction: column;
   margin: 15px 0;
 }
 
-.example-radio-button {
+.error-radio-button {
   margin: 5px;
 }
 
-.reload-logs-button{
-    font-family: 'Montserrat', sans-serif;
-    color: #FFFFFF;
-    background: #054f72;
+.reload-logs-button {
+  font-family: "Montserrat", sans-serif;
+  color: #ffffff;
+  background: #054f72;
 }
 
-.remove-logs-checkbox{
-    font-family: 'Montserrat', sans-serif;
-    color:  #054f72;
+.remove-logs-checkbox {
+  font-family: "Montserrat", sans-serif;
+  color: #054f72;
 }

--- a/frontend/src/app/processes/processes.component.html
+++ b/frontend/src/app/processes/processes.component.html
@@ -1,139 +1,137 @@
-<!doctype html>
-<html>
-<head>
-</head>
-<body>
-    <mat-grid-list cols="2" gutterSize="10px" class="grid">
-        <mat-grid-tile [colspan]="1" [rowspan]="1">
-            <div class='container-img'>
-                <p class='instructions-text'>
-                    Scroll to zoom, drag and click to pan
-                </p>
-                <app-graph-display [dotString]="dotString"></app-graph-display>
-            </div>
-        </mat-grid-tile>
-        <div class="overlay" *ngIf="spinnerWait">
-            <div class="centerSpinner">
-                <mat-progress-spinner class="custom-spinner" mode="indeterminate" style="margin:0 auto;" *ngIf="spinnerWait">
-                </mat-progress-spinner>
-            </div>
+<div class="container-content">
+  <div class="container-content-rows" fxFlex="100%" fxLayout="row">
+    <div fxFlex="100%" #displayDiv class="container-img">
+      <p class="instructions-text">
+        Scroll to zoom, drag and click to pan
+      </p>
+      <app-graph-display [dotString]="dotString" [width]="displayDiv.width" [height]="displayDiv.height">
+      </app-graph-display>
+    </div>
+    <div class="overlay" *ngIf="spinnerWait">
+      <div class="centerSpinner">
+        <mat-progress-spinner class="custom-spinner" mode="indeterminate" style="margin:0 auto;" *ngIf="spinnerWait">
+        </mat-progress-spinner>
+      </div>
+    </div>
+    <div fxFlex="*" class="container container-controls" fxLayout="column" fxLayoutWrap fxLayoutGap="0.5%"
+      fxLayoutAlign="stretch">
+      <!-- Load, Reset buttons -->
+      <div fxLayout="row" fxLayoutAlign="center">
+        <div fxFlex="25%" fxLayoutAlign="center">
+          <button (click)="loadGraph()" class="load-graph-button" mat-raised-button>
+            Load Graph
+          </button>
         </div>
-        <mat-grid-tile [colspan]="1" [rowspan]="2">
-            <div class="container container-controls" fxLayout="column" fxLayoutWrap fxLayoutGap="0.5%" fxLayoutAlign="stretch">
-                <div fxFlex="33%" class="controls-main-selectors">
-                    <div fxLayout="column" fxLayoutAlign="stretch">
-                        <div fxFlex="40%">
-                            <div fxLayout="row" fxLayoutAlign="center stretch">
-                                <div fxFlex="25%" class="controls-main-selectors-labels">
-                                    Graph Type
-                                </div>
-                                <div fxFlex="75%">
-                                    <mat-form-field floatLabel='never'>
-                                        <mat-label>Select  </mat-label>
-                                        <mat-select [(ngModel)]="selectedGraphType">
-                                            <mat-option *ngFor="let GraphType of graphTypes" [value]="GraphType.item">
-                                                {{ GraphType.viewValue }}
-                                            </mat-option>
-                                        </mat-select>
-                                    </mat-form-field>
-                                </div>
-                            </div>
-                        </div>
-                        <div fxFlex="40%">
-                            <div fxLayout="row" fxLayoutAlign="center stretch">
-                                <div fxFlex="25%" class="controls-main-selectors-labels">
-                                    Approach
-                                </div>
-                                <div fxFlex="75%">
-                                    <mat-form-field floatLabel='never'>
-                                        <mat-label>Select  </mat-label>
-                                        <mat-select [(ngModel)]="selectedApproach">
-                                            <mat-option *ngFor="let approach of approaches" [value]="approach.item">
-                                                {{ approach.viewValue }}
-                                            </mat-option>
-                                        </mat-select>
-                                    </mat-form-field>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <mat-divider></mat-divider>
-                <div fxFlex="33%" class="controls-main-selectors">
-                    <!-- Method section -->
-                    <div fxLayout="column" fxLayoutAlign="stretch">
-                        <div fxFlex="25%">
-                            <div fxLayout="row">
-                                <div fxFlex="25%"  class="controls-main-selectors-labels">
-                                    Method
-                                </div>
-                            </div>
-                        </div>
-                        <div fxFlex="75%">
-                            <div fxLayout="row" fxLayoutAlign="stretch">
-                              <div fxFlex="100%">
-                                 <app-chart chartid='methodchart' [data]='methodChartData' [selected]='selectedMethod' (selectOn)='selectMethod($event)'></app-chart>
-                              </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <mat-divider></mat-divider>
-                <div fxFlex="33%" class="controls-main-selectors">
-                    <!-- Method section -->
-                    <div fxLayout="column" fxLayoutAlign="stretch">
-                        <div fxFlex="25%">
-                            <div fxLayout="row">
-                                <div fxFlex="25%"  class="controls-main-selectors-labels">
-                                    Banks
-                                </div>
-                            </div>
-                        </div>
-                        <div fxFlex="75%">
-                            <div fxLayout="row" fxLayoutAlign="stretch">
-                              <div fxFlex="100%">
-                                 <app-chart chartid='bankchart' [data]='bankChartData' [selected]='selectedBank' (selectOn)='selectBank($event)'></app-chart>
-                              </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <mat-divider></mat-divider>
-                <div fxFlex="33%" class="controls-main-selectors-label">
-                    ERRORS
-              <mat-radio-group
-                aria-labelledby="example-radio-group-label"
-                class="example-radio-group"
-                [(ngModel)]="selectedError">
-                <mat-radio-button class="example-radio-button" *ngFor="let error of errors" [value]="error.item">
-                  {{error.viewValue}}
-                </mat-radio-button>
-              </mat-radio-group>
-            </div>
-            <br>
-                <!-- Load, Reset buttons -->
-                <div fxFlex="20%">
-                  <div fxLayout="row" fxLayoutAlign="left">
-                    <div fxFlex="20%" fxLayoutAlign="left center">
-                      <button (click) ="loadGraph()" class='load-graph-button' mat-raised-button>Load Graph</button>
-                    </div>
-                    <div fxFlex="20%" fxLayoutAlign="center">
-                      <button (click) ="reset()" class='reset-settings-button' mat-raised-button>Reset</button>
-                    </div>
+        <div fxFlex="25%" fxLayoutAlign="left center">
+          <button (click)="reset()" class="reset-settings-button" mat-raised-button>
+            Reset
+          </button>
+        </div>
+        <div fxLayoutAlign="left center">
+          <button (click)="reloadLogs()" class='reload-logs-button' mat-raised-button>
+            Reload Logs
+          </button>
+          &nbsp;
+          <mat-checkbox class='remove-logs-checkbox' color="primary" [(ngModel)]="forceRefresh">
+            Clear old data
+          </mat-checkbox>
+        </div>
+      </div>
+      <!-- filters -->
+      <div style="overflow-y: scroll;" class="container container-filters" fxLayout="column" fxLayoutWrap
+        fxLayoutGap="0.5%" fxLayoutAlign="stretch">
+        <div class="container container-controls" fxLayout="column" fxLayoutWrap fxLayoutGap="0.5%"
+          fxLayoutAlign="stretch">
+          <div fxFlex="33%" class="controls-main-selectors">
+            <div fxLayout="column" fxLayoutAlign="stretch">
+              <div fxFlex="40%">
+                <div fxLayout="row" fxLayoutAlign="center stretch">
+                  <div fxFlex="25%" class="controls-main-selectors-labels">
+                    Graph Type
+                  </div>
+                  <div fxFlex="75%">
+                    <mat-form-field floatLabel='never'>
+                      <mat-label>Select </mat-label>
+                      <mat-select [(ngModel)]="selectedGraphType">
+                        <mat-option *ngFor="let GraphType of graphTypes" [value]="GraphType.item">
+                          {{ GraphType.viewValue }}
+                        </mat-option>
+                      </mat-select>
+                    </mat-form-field>
                   </div>
                 </div>
-                <div fxFlex="20%">
-                    <div fxLayout="row" fxLayoutAlign="left">
-                      <div fxFlex="20%" fxLayoutAlign="left center">
-                        <button (click) ="reloadLogs()" class='reload-logs-button' mat-raised-button>Reload Logs</button>
-                      </div>
-                      <div fxFlex="40%" fxLayoutAlign="center">
-                        <mat-checkbox class='remove-logs-checkbox' color="primary" [(ngModel)]="forceRefresh">Remove Stored Logs</mat-checkbox>
-                      </div>
-                    </div>
+              </div>
+              <div fxFlex="40%">
+                <div fxLayout="row" fxLayoutAlign="center stretch">
+                  <div fxFlex="25%" class="controls-main-selectors-labels">
+                    Approach
                   </div>
+                  <div fxFlex="75%">
+                    <mat-form-field floatLabel='never'>
+                      <mat-label>Select </mat-label>
+                      <mat-select [(ngModel)]="selectedApproach">
+                        <mat-option *ngFor="let approach of approaches" [value]="approach.item">
+                          {{ approach.viewValue }}
+                        </mat-option>
+                      </mat-select>
+                    </mat-form-field>
+                  </div>
+                </div>
+              </div>
             </div>
-        </mat-grid-tile>
-    </mat-grid-list>
-</body>
-</html>
+          </div>
+          <mat-divider></mat-divider>
+          <div fxFlex="33%" class="controls-main-selectors">
+            <!-- Method section -->
+            <div fxLayout="column" fxLayoutAlign="stretch">
+              <div fxFlex="25%">
+                <div fxLayout="row">
+                  <div fxFlex="25%" class="controls-main-selectors-labels">
+                    Method
+                  </div>
+                </div>
+              </div>
+              <div fxFlex="75%">
+                <div fxLayout="row" fxLayoutAlign="stretch">
+                  <div fxFlex="100%">
+                    <app-chart chartid='methodchart' [data]='methodChartData' [selected]='selectedMethod'
+                      (selectOn)='selectMethod($event)'></app-chart>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <mat-divider></mat-divider>
+          <!-- Banks section -->
+          <div fxFlex="33%" class="controls-main-selectors">
+            <div fxLayout="column" fxLayoutAlign="stretch">
+              <div fxFlex="25%">
+                <div fxLayout="row">
+                  <div fxFlex="25%" class="controls-main-selectors-labels">
+                    Banks
+                  </div>
+                </div>
+              </div>
+              <div fxFlex="75%">
+                <div fxLayout="row" fxLayoutAlign="stretch">
+                  <div fxFlex="100%">
+                    <app-chart chartid='bankchart' [data]='bankChartData' [selected]='selectedBank'
+                      (selectOn)='selectBank($event)'></app-chart>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <mat-divider></mat-divider>
+          <!-- error section -->
+          <div fxFlex="33%" class="controls-main-selectors-label">
+            Errors
+            <mat-radio-group aria-labelledby="error-radio-group-label" class="error-radio-group"
+              [(ngModel)]="selectedError">
+              <mat-radio-button class="error-radio-button" *ngFor="let error of errors" [value]="error.item">
+                {{error.viewValue}}
+              </mat-radio-button>
+            </mat-radio-group>
+          </div>
+        </div>
+      </div>


### PR DESCRIPTION
This adds a divided scroll layout for the processes page
- filters can be scrolled without moving the graph if graph fits on page
- graph div gets resized to allow looking at details of very "long" graphs